### PR TITLE
Added prawn-layout which seems to what the table DSL was built on

### DIFF
--- a/invoice_printer.gemspec
+++ b/invoice_printer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'prawn'
-  spec.add_dependency 'prawn-table'
+  spec.add_dependency 'prawn-layout'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
After several hours of debugging errors creating the PDF `NoMethodError (undefined method headers=' for #<Prawn::Table:0x007fd76ad1e658>`

Referenced from http://www.rubydoc.info/gems/prawn-layout/0.8.4/Prawn/Table
I realized that this part of the source code was actually using prawn-layout DSL

```ruby
def build_items
      @pdf.move_down(25 + @push_items_table + @push_down)

      items_params = determine_items_structure
      items = build_items_data(items_params)
      headers = build_items_header(items_params)

      styles = {
        headers: headers,
        row_colors: ['F5F5F5', nil],
        width: 550,
        align: {
          0 => :left,
          1 => :right,
          2 => :right,
          3 => :right,
          4 => :right,
          5 => :right,
          6 => :right,
          7 => :right
        }
      }

      @pdf.table(items, styles) unless items.empty?
    end
```

Super thanks for this library 👍 