### PR TITLE
Give more flexibility to purchaser_lines.

### DIFF
--- a/lib/invoice_printer/pdf_document.rb
+++ b/lib/invoice_printer/pdf_document.rb
@@ -324,18 +324,14 @@ module InvoicePrinter
       end
       # Render purchaser_lines if present
       if !@document.purchaser_lines.empty?
-        lines = @document.purchaser_lines.split("\n")
-        line_y = 618
-        lines.each_with_index do |line, index|
-          next if index > 3
-
-          @pdf.text_box(
-            "#{line}",
-            size: 10,
-            at: [x(284), y(line_y - index*15) - @push_down],
-            width: x(240)
-          )
-        end
+        @pdf.text_box(
+          @document.purchaser_lines,
+          size: 10,
+          at: [x(284), y(618) - @push_down],
+          width: x(246),
+          height: y(68),
+          leading: 3,
+        )
       end
       unless @document.purchaser_tax_id.empty?
         @pdf.text_box(


### PR DESCRIPTION
This avoids overlapped text when purchase address is extremely long and therefore provides more options to format the address.

Before:

![Snímek obrazovky z 2022-10-14 23-54-13](https://user-images.githubusercontent.com/14406/195950142-a91e73c3-d33b-4375-a48e-f66c265d55f3.png)

After:

![Snímek obrazovky z 2022-10-14 23-54-40](https://user-images.githubusercontent.com/14406/195950170-85742fc1-b44b-45ba-aca1-6b1674a19ca0.png)

Actually, I'd be even happier if the `purchaser_name` could contain the "John Doe, Nemocnice Nové Město na Moravě, příspěvková organizace" probably broken to multiple lines. But that would need more text flowing. I tried but failed :/

BTW I have not tried to execute the test suite, so I'm sorry if something gets broken ;)