### PR TITLE
Limit stamp size.

### DIFF
--- a/lib/invoice_printer/pdf_document.rb
+++ b/lib/invoice_printer/pdf_document.rb
@@ -853,7 +853,7 @@ module InvoicePrinter
     def build_stamp
       if @stamp && !@stamp.empty?
         @pdf.move_down(15)
-        @pdf.image(@stamp, position: :right)
+        @pdf.image(@stamp, position: :right, fit: [200, 40])
       end
     end
 

--- a/lib/invoice_printer/pdf_document.rb
+++ b/lib/invoice_printer/pdf_document.rb
@@ -853,7 +853,7 @@ module InvoicePrinter
     def build_stamp
       if @stamp && !@stamp.empty?
         @pdf.move_down(15)
-        @pdf.image(@stamp, position: :right, fit: [200, 40])
+        @pdf.image(@stamp, position: :right, fit: [x(200), y(40)])
       end
     end
 


### PR DESCRIPTION
Due to printing, it makes sense to embed the stamp size in high resolution. For example, my stamp has size 655x151. Due to this, the stamp might grow into unreasonable sizes and mangle the whole invoice. Therefore give it some bounding box to fit in.