### PR TITLE
Combine purchaser_name together with purchaser_lines

### DIFF
--- a/lib/invoice_printer/pdf_document.rb
+++ b/lib/invoice_printer/pdf_document.rb
@@ -297,8 +297,10 @@ module InvoicePrinter
     #    ------------------------------------------
     #
     def build_purchaser_box
+      purchaser = [@document.purchaser_name, @document.purchaser_lines].join("\n")
+
       @pdf.text_box(
-        @document.purchaser_name,
+        purchaser.lines.first,
         size: 15,
         at: [x(284), y(640) - @push_down],
         width: x(240)
@@ -320,9 +322,9 @@ module InvoicePrinter
         )
       end
       # Render purchaser_lines if present
-      if !@document.purchaser_lines.empty?
+      if purchaser.lines.size > 1
         @pdf.text_box(
-          @document.purchaser_lines,
+          purchaser.lines(chomp: true)[1..].join("\n"),
           size: 10,
           at: [x(284), y(618) - @push_down],
           width: x(246),


### PR DESCRIPTION
Quite often the purchaser name looks like:

~~~
John Doe,
Foo Inc.
~~~

Where the invoice is prepared for John Doe from Foo Inc. company. If this is the case, the `purchaser_name` becomes too long and ovelaps the `purchaser_lines.

The overlapping can be avoided by combining the `purchaser_name` and `purchaser_lines`, outputting just the first line in bold and treating the rest just as an address. This should provide the greatest flexibility and it is actually extension to #77.

Before:

![obrazek](https://user-images.githubusercontent.com/14406/226485291-1f108609-ed64-4961-85ba-dcb019cfbb81.png)

After:

![obrazek](https://user-images.githubusercontent.com/14406/226485175-83ef3bea-77c5-4899-8cb7-d1937579f513.png)
