### PR TITLE
Chore: removes bold font variants from packaged gem

### DIFF
--- a/invoice_printer.gemspec
+++ b/invoice_printer.gemspec
@@ -11,10 +11,13 @@ ONLY_FONTS_FILES = [
   'FONTS_LICENSE.txt',
   'assets/fonts/overpass/OFL-1.1.txt',
   'assets/fonts/overpass/Overpass-Regular.ttf',
+  'assets/fonts/overpass/Overpass-Bold.ttf',
   'assets/fonts/opensans/Apache-2.0.txt',
   'assets/fonts/opensans/OpenSans-Regular.ttf',
+  'assets/fonts/opensans/OpenSans-Bold.ttf',
   'assets/fonts/roboto/Apache-2.0.txt',
   'assets/fonts/roboto/Roboto-Regular.ttf',
+  'assets/fonts/roboto/Roboto-Bold.ttf',
   'lib/invoice_printer/fonts.rb'
 ]
 


### PR DESCRIPTION
This pull request includes a small change to the `invoice_printer.gemspec` file. The change adds bold font files for Overpass, OpenSans, and Roboto to the `ONLY_FONTS_FILES` array.

* [`invoice_printer.gemspec`](diffhunk://#diff-2cf88614cc8a9d218c9d997935760baace329f78427b2dc52e8614cc1b8e9874R14-R20): Added `Overpass-Bold.ttf`, `OpenSans-Bold.ttf`, and `Roboto-Bold.ttf` to the `ONLY_FONTS_FILES` array.

This results in the bold font variants being excluded from the packaged gem file.