### PR TITLE
chore: adds ruby v3.3, but keeps ruby-head commented out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         ruby:
           - "3.1"
           - "3.2"
+          - "3.3"
           # - "ruby-head"
     steps:
       - name: Install system dependencies


### PR DESCRIPTION
ruby-head should be targeting ruby 3.4 if I'm not mistaken.